### PR TITLE
Async fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/abundance-service",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "API for expressing and matching needs",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -51,9 +51,12 @@ const need = async (connectorName, what) => {
 
   let serviceInformationObserve = await core.observe(matchClaim.did, ssid)
 
-  let serviceInformation = await serviceInformationObserve.takeOne()
+  let serviceInformationPromise = serviceInformationObserve.takeOne()
+  await serviceInformationObserve._readyPromise
 
   let myPrivateSsid = await refer(ssid, matchClaim.did)
+
+  let serviceInformation = await serviceInformationPromise
 
   return {
     'needSsid': ssid,

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,11 @@ const observeOffer = async (did, ssid) => {
 
   let resultPromise = observeResult.takeOne().then(async (offer) => {
     let resultLink = offer['claim']['data'][ABUNDANCE_SERVICE_OFFER_PREDICATE]
-    return core.get(resultLink, ssid)
+    let resultClaim = await core.get(resultLink, ssid)
+    return {
+      'claim': resultClaim,
+      'link': resultLink
+    }
   })
 
   return { 'resultPromise': resultPromise, 'readyPromise': observeResult._readyPromise }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const need = async (connectorName, what) => {
 
   let serviceInformationObserve = await core.observe(matchClaim.did, ssid)
 
-  let serviceInformationPromise = serviceInformationObserve.takeOne()
+  let serviceInformation = await serviceInformationObserve.takeOne()
 
   let myPrivateSsid = await refer(ssid, matchClaim.did)
 
@@ -59,7 +59,7 @@ const need = async (connectorName, what) => {
     'needSsid': ssid,
     'myPrivateSsid': myPrivateSsid,
     'theirPrivateDid': matchClaim['did'],
-    'serviceInformationPromise': serviceInformationPromise
+    'serviceInformationPromise': serviceInformation
   }
 }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -47,8 +47,6 @@ describe('descipl-abundance-service-api', () => {
 
       let need = await svc.need('ephemeral', 'beer')
 
-      await need.serviceInformationPromise
-
       let observeOffer = await svc.observeOffer(need.theirPrivateDid, need.myPrivateSsid)
 
       await observeOffer.readyPromise

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -49,11 +49,13 @@ describe('descipl-abundance-service-api', () => {
 
       await need.serviceInformationPromise
 
-      let resultPromise = svc.observeOffer(need.theirPrivateDid, need.myPrivateSsid)
+      let observeOffer = await svc.observeOffer(need.theirPrivateDid, need.myPrivateSsid)
+
+      await observeOffer.readyPromise
 
       await svc.getCoreAPI().claim(need.myPrivateSsid, { 'BSN': '123123123' })
 
-      let result = await resultPromise
+      let result = await observeOffer.resultPromise
 
       expect(result.data).to.deep.equal({
         'BSN': '123123123',

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -55,10 +55,12 @@ describe('descipl-abundance-service-api', () => {
 
       let result = await observeOffer.resultPromise
 
-      expect(result.data).to.deep.equal({
+      expect(result.claim.data).to.deep.equal({
         'BSN': '123123123',
         'woonplaats': 'Haarlem'
       })
+
+      expect(result.link).to.be.a('string')
     })
   })
 })


### PR DESCRIPTION
This propagates the readyPromise to the final consumer to provide fine-grained control to ensure a subscription has really started before moving on in the process.